### PR TITLE
Add 'level' reporting to mirror position

### DIFF
--- a/Rollease Acmeda/Rollease Acmeda Shade.groovy
+++ b/Rollease Acmeda/Rollease Acmeda Shade.groovy
@@ -208,6 +208,7 @@ def positionUpdated(position) {
         
         
         sendEvent(name: "position", value: position)
+        sendEvent(name: "level", value: position)
         sendEvent(name: "moving", value: false)
 }
 


### PR DESCRIPTION
Improve compatibility with automations and other apps by also reporting the 'level' attribute since the device declares the Switch Level capability.